### PR TITLE
Fix missing discord.Bot error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
    ```bash
    pip install -r requirements.txt
    ```
+   **注意**: `discord` パッケージではなく、Pycord (`py-cord`) を使用します。誤って
+   `discord.py` や `discord` をインストールしていると、`discord.Bot` が
+   見つからないエラーが発生します。
 4. プロジェクトルートに `.env` ファイルを作成し、次の内容を設定します。
    ```
    DISCORD_TOKEN="YOUR_DISCORD_BOT_TOKEN"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-cord
+py-cord>=2.6
 faster-whisper
 python-dotenv
 aiodiskqueue


### PR DESCRIPTION
## Summary
- document that Pycord is required
- specify minimum Pycord version

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6868f7c43bc483309fed2f258e01a4ec