### PR TITLE
Implement queue directory creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,9 @@ async def on_ready():
     print(f"{bot.user}としてログインしました。")
 
 async def setup_bot():
-    queue = await aiodiskqueue.Queue.create("./data/queue")
+    queue_path = os.path.join(".", "data", "queue")
+    os.makedirs(queue_path, exist_ok=True)
+    queue = await aiodiskqueue.Queue.create(queue_path)
     bot.transcription_queue = queue
 
     from cogs import setup_cog, recording_cog


### PR DESCRIPTION
## Summary
- queueディレクトリが存在しない場合に作成するよう`setup_bot`を修正

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868fc180bc88330804e625aba57e268