### PR TITLE
Switch to google-genai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ py-cord>=2.6
 faster-whisper
 python-dotenv
 aiodiskqueue
-google-generativeai
+google-genai


### PR DESCRIPTION
## Summary
- migrate from deprecated `google-generativeai` to `google-genai`
- adapt Gemini processor to new client API
- update library references in docs and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686904ae925c83308025fa63e1e182ed