### PR TITLE
Fix bot initialization and session cleanup

### DIFF
--- a/cogs/recording_cog.py
+++ b/cogs/recording_cog.py
@@ -7,9 +7,8 @@ from core.session_manager import RecordingSessionManager
 class RecordingCog(commands.Cog):
     def __init__(self, bot: discord.Bot):
         self.bot = bot
-        self.session_manager = RecordingSessionManager(
-            bot, bot.transcription_queue
-        )
+        # Botインスタンスが持つセッションマネージャーを参照する
+        self.session_manager = bot.session_manager
 
     @commands.Cog.listener()
     async def on_voice_state_update(


### PR DESCRIPTION
## Summary
- ensure bot initialization happens in one event loop using `setup_hook`
- reuse bot-level session manager in recording cog
- add waiting and cleanup when stopping recordings

## Testing
- `python -m py_compile main.py cogs/recording_cog.py core/session_manager.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869181fe1c48330a7708c7a38f2a197