### PR TITLE
Fix slash command registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
    GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
    TRANSCRIPTION_MODEL="small"     # 任意
    GEMINI_MODEL="gemini-2.5-flash" # 任意
+   TEST_GUILD_ID="YOUR_TEST_GUILD_ID" # 任意: スラッシュコマンドを即時反映させたいテストサーバーID
    ```
 5. Bot を起動します。データディレクトリ(`data/queue`, `data/recordings`) は起動時に自動で作成されます。
    ```bash

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ def ensure_env() -> None:
                 "GEMINI_API_KEY=\"YOUR_GEMINI_API_KEY\"\n"
                 "TRANSCRIPTION_MODEL=\"small\"\n"
                 "GEMINI_MODEL=\"gemini-2.5-flash\"\n"
+                "TEST_GUILD_ID=\"YOUR_TEST_GUILD_ID\"\n"
             )
     print(".env が見つかりませんでした。 .env.example を生成しました。必要事項を記入し .env を作成してください。")
 
@@ -61,7 +62,9 @@ class MyBot(discord.Bot):
         print("セットアップが完了し、文字起こしワーカーが起動しました。")
 
 
-bot = MyBot(intents=intents)
+test_guild = os.getenv("TEST_GUILD_ID")
+test_guilds = [int(test_guild)] if test_guild else None
+bot = MyBot(intents=intents, test_guilds=test_guilds)
 
 
 @bot.event


### PR DESCRIPTION
## Summary
- register slash commands instantly by allowing a test guild
- document `TEST_GUILD_ID` environment variable

## Testing
- `python -m py_compile main.py cogs/setup_cog.py cogs/recording_cog.py core/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686925288008833099cb140e05a13cb9